### PR TITLE
Rembot does not exit on week 9 every year and sends mail when it's not supposed to do so

### DIFF
--- a/rembot.sh
+++ b/rembot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # skip odd weeks, this script is executed on Sunday
-week=$(date +%V)
+week=$(date +%-V)
 if [ $(($week % 2)) != 0 ]
 then
         exit


### PR DESCRIPTION
date() gives weeks with leading zeros. Bash interprets those as octals. This was no problem because octal 01 - 08 is equal to dec 1 - 8. But on week 09 it failed because 09 is invalid in octal. Starting with week 10 all is fine again because than date adds no leading zeros anymore